### PR TITLE
Heroku 18 ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/bundler/*
 vendor/bundle/*
 .env
 .ruby-version
+.ruby-gemset
 buildpacks/*
 .anvil/
 tmp/*.log

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.5'
-
 group :development, :test do
   gem "heroku_hatchet"
   gem "rspec-core"


### PR DESCRIPTION
* add gemset files to ignore
* remove ruby version from the gefile
* revert the ruby language pack to the way it was before requiring ruby 2.4.5